### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -7,7 +7,7 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 
 #=================================================
 # MODIFY URL IN NGINX CONF

--- a/scripts/install
+++ b/scripts/install
@@ -18,7 +18,7 @@ ynh_nodejs_install
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 key=$(ynh_string_random --length=32)
 
 ynh_app_setting_set --key=php_upload_max_filesize --value=50M

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -12,7 +12,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression "Ensuring downward compatibility..."
 
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 
 ynh_app_setting_set_default --key=php_upload_max_filesize --value=100M
 ynh_app_setting_set_default --key=php_post_max_size --value=100M


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.